### PR TITLE
Check that Duster is compatible with supported PHP versions

### DIFF
--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -1,0 +1,41 @@
+name: Compatibility check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [Ubuntu, Windows, macOS]
+        php: [7.4, 8.0]
+
+        include:
+          - os: Ubuntu
+            os-version: ubuntu-latest
+
+          - os: Windows
+            os-version: windows-latest
+
+          - os: macOS
+            os-version: macos-latest
+
+    name: ${{ matrix.os }} - PHP ${{ matrix.php }}
+
+    runs-on: ${{ matrix.os-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs


### PR DESCRIPTION
This PR introduces a very simple GitHub workflow to check that Duster will install on supported OS/PHP version combinations.

Fixes #27 in conjunction with https://github.com/tighten/tighten-coding-standard/pull/3.