### PR TITLE
add phpcs path to github action

### DIFF
--- a/stubs/github-actions/lint.yml
+++ b/stubs/github-actions/lint.yml
@@ -26,6 +26,8 @@ jobs:
 
             - name: PHPCS lint
               uses: chekalsky/phpcs-action@v1
+              with:
+                phpcs_bin_path: './vendor/bin/phpcs'
 
     tlint:
         name: TLint


### PR DESCRIPTION
I was facing the following issue when the Github Action tried to run:

![image](https://user-images.githubusercontent.com/13042804/111315125-12fc2a00-8630-11eb-8167-e838fed6ae83.png)

By adding the `with` + `path` to phpcs per the phpcs-actions documentation, it seems to resolve the error.  I told @mattstauffer I would submit the PR for you guys to check out.  :) 