### PR TITLE
Add `phpcodesniffer-composer-installer` info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ composer require tightenco/duster --dev
 ./vendor/bin/duster init
 ```
 
+When installing you may see the following message:
+
+>dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
+>Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
+
+You will need to accept the [phpcodesniffer-composer-installer](https://github.com/PHPCSStandards/composer-installer) to have the PHPCS rulesets and GitHub actions to work.
+
+This adds an `allowed-plugins` entry to your `composer.json` file:
+
+```json
+    ...
+    "config": {
+        ...
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+```
+
+
 You must run `./vendor/bin/duster init` after installing, or you won't have a local copy of the PHPCS config file, and Duster won't work.
 
 The `init` command will also optionally add a GitHub action to run Duster's linters.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When installing you may see the following message:
 >dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
 >Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
 
-You will need to accept the [phpcodesniffer-composer-installer](https://github.com/PHPCSStandards/composer-installer) to have the PHPCS rulesets and GitHub actions to work.
+You will need to accept the [phpcodesniffer-composer-installer](https://github.com/PHPCSStandards/composer-installer) prompt to have the PHPCS rulesets and so the GitHub actions will work.
 
 This adds an `allowed-plugins` entry to your `composer.json` file:
 


### PR DESCRIPTION
This PR adds information on enabling the `phpcodesniffer-composer-installer`  when installing Duster.
Aims to close #36.