### PR TITLE
Drop support for 7.3 and add 8.1

### DIFF
--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -2,7 +2,7 @@ name: Compatibility check
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, Windows, macOS]
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
 
         include:
           - os: Ubuntu

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0|^8.1",
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.5",
         "tightenco/tighten-coding-standard": "^1.0",


### PR DESCRIPTION
This PR drops support for [EOD PHP 7.3](https://phpreleases.com/api/releases/7.3.33) and adds PHP 8.1.

Related: https://github.com/tighten/tighten-coding-standard/pull/10