### PR TITLE
Update GitHub actions 

### DIFF
--- a/bin/actions/init
+++ b/bin/actions/init
@@ -26,7 +26,16 @@ else
 
     mkdir -p .github/workflows
     cp ${BIN_DIR}/../stubs/github-actions/lint.yml $gh_action_filename
-    printf "\nCreated $gh_action_filename.\nPlease edit the file if your primary branch is not 'main'.\n"
+
+    read -p "Enter the name of your primary branch [main]: " primary_branch
+    primary_branch=${primary_branch:-main}
+    sed -i '' "s/YOUR_BRANCH_NAME/${primary_branch}/g" $gh_action_filename
+
+    read -p "Enter your PHP version [8.1]: " php_version
+    php_version=${php_version:-8.1}
+    sed -i '' "s/YOUR_PHP_VERSION/${php_version}/g" $gh_action_filename
+
+    printf "\nCreated $gh_action_filename.\n"
   else
     printf "\nSkipping GitHub Action.\n"
   fi

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
         "tightenco/tlint": "^6.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/stubs/github-actions/lint.yml
+++ b/stubs/github-actions/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
     push:
-        branches: [ main ]
+        branches: [ YOUR_BRANCH_NAME ]
     pull_request:
 
 jobs:
@@ -17,17 +17,15 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: YOUR_PHP_VERSION
                   extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 
             - name: Install dependencies
               run: composer install --no-interaction --no-suggest --ignore-platform-reqs
 
-            - name: PHPCS lint
-              uses: chekalsky/phpcs-action@v1
-              with:
-                phpcs_bin_path: './vendor/bin/phpcs'
+            - name: PHPCS Lint
+              run: vendor/bin/phpcs
 
     tlint:
         name: TLint
@@ -42,7 +40,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: YOUR_PHP_VERSION
                   extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 


### PR DESCRIPTION
This PR updates the `init` command to request the primary branch and PHP version.
The `.github/workflows/lint.yml` file is updated using these values.

Added to composer to fix error below:
```javascript
"allow-plugins": {
    "dealerdirect/phpcodesniffer-composer-installer": true
}
```
<img width="670" alt="Screen Shot 2022-09-02 at 10 40 26 PM" src="https://user-images.githubusercontent.com/194221/188257526-01b1efe7-2bb9-4807-8d03-b4d399068f06.png">
