### PR TITLE
Update the pint section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,26 +77,11 @@ Now you can add customizations below the `<rule ref="Tighten"/>` line or even di
 
 ### PHP CS Fixer
 
-Create a `.php-cs-fixer.dist.php` file in your project root with the contents from [Duster's `.php-cs-fixer.dist.php`](.php-cs-fixer.dist.php).  Learn more in the [PHP CS Fixer documentation](https://cs.symfony.com/doc/config.html).
+Create a `.php-cs-fixer.dist.php` file in your project root with the contents from [Duster's `.php-cs-fixer.dist.php`](.php-cs-fixer.dist.php) file. Learn more in the [PHP CS Fixer documentation](https://cs.symfony.com/doc/config.html).
 
 ### Pint
 
-Create a `pint.json` file in your project root with the following:
-
-```json
-{
-    "preset": "laravel",
-    "rules": {
-        "concat_space": {
-            "spacing": "one"
-        },
-        "class_attributes_separation": {
-        }
-    }
-}
-```
-
-Now you can add or remove customizations. Learn more in the [Pint documentation](https://laravel.com/docs/pint#configuring-pint).
+Create a `pint.json` file in your project root, you can use [Duster's `pint.json`](pint.json) file as a starting point. Learn more in the [Pint documentation](https://laravel.com/docs/pint#configuring-pint).
 
 ## Contributing
 
@@ -104,7 +89,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Security
 
-If you discover any security related issues, please email hello@tighten.co instead of using the issue tracker.
+If you discover any security-related issues, please email hello@tighten.co instead of using the issue tracker.
 
 ## Credits
 


### PR DESCRIPTION
The Pint section of the readme is already out of date, opt to link to Duster's `pint.json` instead.