### PR TITLE
Bump TLint to version 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "friendsofphp/php-cs-fixer": "^3.11",
         "laravel/pint": "^1.2",
         "squizlabs/php_codesniffer": "^3.7",
-        "tightenco/tlint": "^6.0"
+        "tightenco/tlint": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR bumps the TLint version to 7.0
Relies on https://github.com/tighten/tlint/pull/297