### PR TITLE
Add custom `UseConfigOverEnv` sniff

### DIFF
--- a/standards/Tighten/Sniffs/PHP/UseConfigOverEnvSniff.php
+++ b/standards/Tighten/Sniffs/PHP/UseConfigOverEnvSniff.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tighten\Sniffs\PHP;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+
+class UseConfigOverEnvSniff extends ForbiddenFunctionsSniff
+{
+    public $forbiddenFunctions = [
+        'env' => 'config',
+    ];
+}

--- a/standards/Tighten/ruleset.xml
+++ b/standards/Tighten/ruleset.xml
@@ -48,7 +48,6 @@
     </rule>
 
     <!-- No compact() and no 'dumps' -->
-    <!-- Use config() over env() -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array">
@@ -57,10 +56,12 @@
                 <element key="dump" value="null"/>
                 <element key="var_dump" value="null"/>
                 <element key="ray" value="null"/>
-                <element key="env" value="config"/>
             </property>
         </properties>
-        <!-- This will also allow all other forbidden functions in confg directory -->
+    </rule>
+
+    <!-- Use config() over env() -->
+    <rule ref="Tighten.PHP.UseConfigOverEnv">
         <exclude-pattern>/config/*</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
This PR fixes an issue where allowing `env()` in the config directory also allowed other forbidden functions.

Added new `UseConfigOverEnvSniff`, which allows us to exclude only that rule from the config directory. 