### PR TITLE
Order PHPUnit methods at top of classes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ return (new Config())
                 'property_public',
                 'property_protected',
                 'property_private',
+                'phpunit',
                 'construct',
                 'invoke',
                 'method_public_static',

--- a/tests/Fixer/ClassNotation/CustomOrderedClassElements/.php-cs-fixer.php
+++ b/tests/Fixer/ClassNotation/CustomOrderedClassElements/.php-cs-fixer.php
@@ -19,6 +19,7 @@ return (new Config())
                 'property_public',
                 'property_protected',
                 'property_private',
+                'phpunit',
                 'construct',
                 'invoke',
                 'method_public_static',


### PR DESCRIPTION
This PR closes #50 

Ordering PHPUnit classes above other test methods.