### PR TITLE
Add `global_namespace_import`

### DIFF
--- a/app/Fixer/ClassNotation/CustomControllerOrderFixer.php
+++ b/app/Fixer/ClassNotation/CustomControllerOrderFixer.php
@@ -6,6 +6,7 @@ namespace App\Fixer\ClassNotation;
 
 use LogicException;
 use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
 
 class CustomControllerOrderFixer extends CustomOrderedClassElementsFixer
 {
@@ -102,7 +103,7 @@ class CustomControllerOrderFixer extends CustomOrderedClassElementsFixer
         return false;
     }
 
-    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
     {
         for ($index = $tokens->count() - 1; $index > 0; $index--) {
             if ($tokens[$index]->isGivenKind(T_NAMESPACE) && $this->isControllerClass($tokens, $index)) {

--- a/app/Fixer/ClassNotation/CustomOrderedClassElementsFixer.php
+++ b/app/Fixer/ClassNotation/CustomOrderedClassElementsFixer.php
@@ -28,6 +28,13 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+use function array_key_exists;
+use function count;
+use function defined;
+use function in_array;
+use function is_array;
 
 /**
  * @author Gregor Harlan <gharlan@web.de>
@@ -142,7 +149,7 @@ class CustomOrderedClassElementsFixer extends AbstractFixer implements Configura
             $this->typePosition[$type] = null;
         }
 
-        $lastPosition = \count($this->configuration['order']);
+        $lastPosition = count($this->configuration['order']);
 
         foreach ($this->typePosition as &$pos) {
             if (null === $pos) {
@@ -242,7 +249,7 @@ class Example
     /**
      * {@inheritdoc}
      */
-    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
     {
         for ($i = 1, $count = $tokens->count(); $i < $count; $i++) {
             if (! $tokens[$i]->isClassy()) {
@@ -252,12 +259,12 @@ class Example
             $i = $tokens->getNextTokenOfKind($i, ['{']);
             $elements = $this->getElements($tokens, $i);
 
-            if (0 === \count($elements)) {
+            if (0 === count($elements)) {
                 continue;
             }
 
             $sorted = $this->sortElements($elements);
-            $endIndex = $elements[\count($elements) - 1]['end'];
+            $endIndex = $elements[count($elements) - 1]['end'];
 
             if ($sorted !== $elements) {
                 $this->sortTokens($tokens, $i, $endIndex, $sorted);
@@ -280,7 +287,7 @@ class Example
                 ->setAllowedValues([
                     static function (array $values) use ($builtIns): bool {
                         foreach ($values as $value) {
-                            if (\in_array($value, $builtIns, true)) {
+                            if (in_array($value, $builtIns, true)) {
                                 return true;
                             }
 
@@ -365,7 +372,7 @@ class Example
                     continue;
                 }
 
-                if (\defined('T_READONLY') && $token->isGivenKind(T_READONLY)) { // @TODO: drop condition when PHP 8.1+ is required
+                if (defined('T_READONLY') && $token->isGivenKind(T_READONLY)) { // @TODO: drop condition when PHP 8.1+ is required
                     $element['readonly'] = true;
                 }
 
@@ -381,7 +388,7 @@ class Example
 
                 $type = $this->detectElementType($tokens, $i);
 
-                if (\is_array($type)) {
+                if (is_array($type)) {
                     $element['type'] = $type[0];
                     $element['name'] = $type[1];
                 } else {
@@ -390,7 +397,7 @@ class Example
 
                 if ('property' === $element['type']) {
                     $element['name'] = $tokens[$i]->getContent();
-                } elseif (\in_array($element['type'], ['use_trait', 'case', 'constant', 'method', 'magic', 'construct', 'destruct'], true)) {
+                } elseif (in_array($element['type'], ['use_trait', 'case', 'constant', 'method', 'magic', 'construct', 'destruct'], true)) {
                     $element['name'] = $tokens[$tokens->getNextMeaningfulToken($i)]->getContent();
                 }
 
@@ -503,13 +510,13 @@ class Example
         foreach ($elements as &$element) {
             $type = $element['type'];
 
-            if (\in_array($type, ['method', 'magic', 'phpunit'], true) && isset($this->typePosition["method:{$element['name']}"])) {
+            if (in_array($type, ['method', 'magic', 'phpunit'], true) && isset($this->typePosition["method:{$element['name']}"])) {
                 $element['position'] = $this->typePosition["method:{$element['name']}"];
 
                 continue;
             }
 
-            if (\array_key_exists($type, self::$specialTypes)) {
+            if (array_key_exists($type, self::$specialTypes)) {
                 if (isset($this->typePosition[$type])) {
                     $element['position'] = $this->typePosition[$type];
 
@@ -523,7 +530,7 @@ class Example
                 $type = 'method';
             }
 
-            if (\in_array($type, ['constant', 'property', 'method'], true)) {
+            if (in_array($type, ['constant', 'property', 'method'], true)) {
                 $type .= '_' . $element['visibility'];
 
                 if ($element['abstract']) {

--- a/app/Fixer/ClassNotation/CustomPhpUnitOrderFixer.php
+++ b/app/Fixer/ClassNotation/CustomPhpUnitOrderFixer.php
@@ -6,6 +6,7 @@ namespace App\Fixer\ClassNotation;
 
 use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
 use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
 
 class CustomPhpUnitOrderFixer extends CustomOrderedClassElementsFixer
 {
@@ -52,7 +53,7 @@ class CustomPhpUnitOrderFixer extends CustomOrderedClassElementsFixer
         return 64;
     }
 
-    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
     {
         $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator;
 

--- a/standards/pint.json
+++ b/standards/pint.json
@@ -1,6 +1,7 @@
 {
     "preset": "laravel",
     "rules": {
+        "blank_line_between_import_groups": true,
         "concat_space": {
             "spacing": "one"
         },
@@ -9,8 +10,15 @@
                 "method": "one"
             }
         },
-        "php_unit_test_annotation": {
-            "style": "annotation"
+        "explicit_string_variable": true,
+        "global_namespace_import": {
+            "import_classes": true,
+            "import_constants": true,
+            "import_functions": true
+        },
+        "new_with_braces": {
+            "named_class": false,
+            "anonymous_class": false
         },
         "ordered_imports": {
             "sort_algorithm": "alpha",
@@ -20,12 +28,9 @@
                 "function"
             ]
         },
-        "new_with_braces": {
-            "named_class": false,
-            "anonymous_class": false
+        "php_unit_test_annotation": {
+            "style": "annotation"
         },
-        "blank_line_between_import_groups": true,
-        "explicit_string_variable": true,
         "simple_to_complex_string_variable": true
     }
 }

--- a/style-guide.md
+++ b/style-guide.md
@@ -1278,6 +1278,41 @@ Renames PHPDoc tags.
   */
 ```
 
+### global_namespace_import
+
+Imports or fully qualifies global classes/functions/constants.
+
+##### Configuration
+
+```php
+[
+    'import_classes' => true,
+    'import_constants' => true,
+    'import_functions' => true,
+]
+```
+
+##### Examples
+
+```diff
+<?php
+
+ namespace Foo;
++use DateTimeImmutable;
++use function count;
++use const M_PI;
+
+-if (\count($x)) {
+-    /** @var \DateTimeImmutable $d */
+-    $d = new \DateTimeImmutable();
+-    $p = \M_PI;
++if (count($x)) {
++    /** @var DateTimeImmutable $d */
++    $d = new DateTimeImmutable();
++    $p = M_PI;
+ }
+```
+
 ### heredoc_to_nowdoc
 
 Convert `heredoc` to `nowdoc` where possible.
@@ -1285,8 +1320,10 @@ Convert `heredoc` to `nowdoc` where possible.
 ##### Examples
 
 ```diff
--<?php $a = <<<"TEST"
-+<?php $a = <<<'TEST'
+<?php
+
+-$a = <<<"TEST"
++$a = <<<'TEST'
  Foo
  TEST;
 ```


### PR DESCRIPTION
This PR adds `global_namespace_import` to the Pint config.

We were trying to do something similar with [TLint](https://github.com/tighten/tlint/pull/329) dropping leading slashes.