### PR TITLE
Move commonly excluded files to DusterConfig

### DIFF
--- a/app/Support/DusterConfig.php
+++ b/app/Support/DusterConfig.php
@@ -12,6 +12,19 @@ class DusterConfig
     public function __construct(
         protected array $config = []
     ) {
+        $this->config['exclude'] = array_merge(
+            $this->config['exclude'] ?? [],
+            [
+                '_ide_helper_actions.php',
+                '_ide_helper_models.php',
+                '_ide_helper.php',
+                '.phpstorm.meta.php',
+                'bootstrap/cache',
+                'build',
+                'node_modules',
+                'storage',
+            ]
+        );
     }
 
     public function get(string $key, mixed $default = null): mixed

--- a/app/Support/PhpCsFixer.php
+++ b/app/Support/PhpCsFixer.php
@@ -22,17 +22,7 @@ class PhpCsFixer extends Tool
     {
         return Finder::create()
             ->notName([
-                '_ide_helper_actions.php',
-                '_ide_helper_models.php',
-                '_ide_helper.php',
-                '.phpstorm.meta.php',
                 '*.blade.php',
-            ])
-            ->exclude([
-                'bootstrap/cache',
-                'build',
-                'node_modules',
-                'storage',
             ])
             ->ignoreDotFiles(true)
             ->ignoreVCS(true);


### PR DESCRIPTION
This PR updates DusterConfig to include commonly excluded files.

This improves the user experience by not requiring additional tool config files to define these exclusions.