### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,19 @@ To fix everything at once:
 ./vendor/bin/duster --fix
 ```
 
+To dust only files that have uncommitted changes according to Git, you may use the `--dirty` option:
+
+```bash
+./vendor/bin/duster --lint --dirty
+#or
+./vendor/bin/duster --fix --dirty
+```
+
 To view all available commands:
 
 ```bash
 ./vendor/bin/duster
-```
-
-or
-
-```bash
+#or
 ./vendor/bin/duster --help
 ```
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -2132,6 +2132,46 @@ There MUST NOT be a space after the opening parenthesis. There MUST NOT be a spa
  }
 ```
 
+### no_superfluous_phpdoc_tags
+
+Removes `@param`, `@return` and `@var` tags that don't provide any useful information.
+
+##### Configuration
+
+```php
+[
+  'no_superfluous_phpdoc_tags' => [
+    'allow_mixed' => true,
+    'allow_unused_params' => true,
+  ],
+]
+```
+
+##### Examples
+
+```diff
+<?php
+ class Foo {
+     /**
+-     * @param Bar $bar
+      * @param mixed $baz
+      */
+     public function doFoo(Bar $bar, $baz) {}
+ }
+```
+
+```diff
+ <?php
+ class Foo {
+     /**
+-     * @param Bar $bar
+-     * @param mixed $baz
+      * @param string|int|null $qux
+      */
+     public function doFoo(Bar $bar, $baz /*, $qux = null */) {}
+ }
+ ```
+
 ### no_trailing_whitespace
 
 Remove trailing whitespace at the end of non-blank lines.


### PR DESCRIPTION
This PR updates the readme to include information on the new `--dirty` option.
The style guide was updated to include `no_superfluous_phpdoc_tags`.