### PR TITLE
Add GitHub workflow to update `.git-blame-ignore-revs`

### DIFF
--- a/app/Commands/GitHubActionsCommand.php
+++ b/app/Commands/GitHubActionsCommand.php
@@ -15,9 +15,9 @@ class GitHubActionsCommand extends Command
     public function handle(): int
     {
         $choices = [
-            'Lint only'=> 'duster-lint',
-            'Fix and commit'=> 'duster-fix',
-            'Fix, commit, and update .git-blame-ignore-revs'=> 'duster-fix-blame',
+            'Lint only' => 'duster-lint',
+            'Fix and commit' => 'duster-fix',
+            'Fix, commit, and update .git-blame-ignore-revs' => 'duster-fix-blame',
         ];
 
         $branch = $this->anticipate('What is the name of your primary branch?', ['main', 'develop', 'master'], 'main');

--- a/app/Commands/GitHubActionsCommand.php
+++ b/app/Commands/GitHubActionsCommand.php
@@ -14,10 +14,16 @@ class GitHubActionsCommand extends Command
 
     public function handle(): int
     {
-        $branch = $this->anticipate('What is the name of your primary branch?', ['main', 'develop', 'master'], 'main');
-        $commit = $this->choice('Would you like the action to automatically commit fixes?', ['yes', 'no'], 1);
+        $choices = [
+            'Lint only'=> 'duster-lint',
+            'Fix and commit'=> 'duster-fix',
+            'Fix, commit, and update .git-blame-ignore-revs'=> 'duster-fix-blame',
+        ];
 
-        $workflowName = $commit === 'yes' ? 'duster-fix' : 'duster-lint';
+        $branch = $this->anticipate('What is the name of your primary branch?', ['main', 'develop', 'master'], 'main');
+        $choice = $this->choice('Which GitHub action would you like?', array_keys($choices), 0);
+
+        $workflowName = $choices[$choice];
 
         $workflow = file_get_contents(__DIR__ . "/../../stubs/github-actions/{$workflowName}.yml");
         $workflow = str_replace('YOUR_BRANCH_NAME', $branch, $workflow);

--- a/stubs/github-actions/duster-fix-blame.yml
+++ b/stubs/github-actions/duster-fix-blame.yml
@@ -1,0 +1,40 @@
+name: Duster Fix
+
+on:
+    push:
+        branches: [ YOUR_BRANCH_NAME ]
+    pull_request:
+
+jobs:
+  duster:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: "Duster Fix"
+        uses: tighten/duster-action@v1
+        with:
+          args: fix
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto_commit_action
+        with:
+          commit_message: Dusting
+          commit_user_name: GitHub Action
+          commit_user_email: actions@github.com
+
+      - name: Ignore Duster commit in git blame
+        if: steps.auto_commit_action.outputs.changes_detected == 'true'
+        run: echo ${{ steps.auto_commit_action.outputs.commit_hash }} >> .git-blame-ignore-revs
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Ignore Dusting commit in git blame
+          commit_user_name: GitHub Action
+          commit_user_email: actions@github.com


### PR DESCRIPTION
This PR adds an additional GitHub action which also updates `.git-blame-ignore-revs`.