### PR TITLE
Allow dev dependencies to be skipped on build

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,14 +3,15 @@
 1. Visit the [Duster Releases page](https://github.com/tighten/duster/releases); figure out what your next tag will be (increase the third number if it's a patch or fix; increase the second number if it's adding features)
 2. On your local machine, pull down the latest changes on the `main` branch (`git checkout main && git pull`)
 3. Update the version in [`config/app.php`](./config/app.php)
-4. Compile the binary with
+4. Remove dev dependencies `composer install --no-dev`
+5. Compile the binary with
 
 ```zsh
 ./duster app:build
 ```
 
-5. Run the build once to make sure it works (`./builds/duster`)
-6. Commit all changes
-7. Push all commits to GitHub
-8. [Draft a new release](https://github.com/tighten/duster/releases/new) with both the tag version and title of your tag (e.g. `v1.5.1`)
-9. Use the "Generate release notes" button to generate release notes from the merged PRs.
+6. Run the build once to make sure it works (`./builds/duster`)
+7. Commit all changes
+8. Push all commits to GitHub
+9. [Draft a new release](https://github.com/tighten/duster/releases/new) with both the tag version and title of your tag (e.g. `v1.5.1`)
+10. Use the "Generate release notes" button to generate release notes from the merged PRs.

--- a/composer.json
+++ b/composer.json
@@ -24,36 +24,36 @@
         }
     ],
     "require": {
-        "php": "^8.0"
-    },
-    "require-dev": {
+        "php": "^8.0",
         "friendsofphp/php-cs-fixer": "^3.14",
         "laravel-zero/framework": "^9.2",
         "laravel/pint": "1.5",
-        "mockery/mockery": "^1.4.4",
-        "nunomaduro/larastan": "^2.2",
         "nunomaduro/termwind": "^1.14",
-        "pestphp/pest": "^1.21.3",
-        "rector/rector": "^0.15.10",
         "spatie/invade": "^1.1",
-        "spatie/laravel-ray": "^1.31",
         "squizlabs/php_codesniffer": "^3.7",
         "tightenco/tlint": "^8.0"
+    },
+    "require-dev": {
+        "mockery/mockery": "^1.4.4",
+        "nunomaduro/larastan": "^2.2",
+        "pestphp/pest": "^1.21.3",
+        "rector/rector": "^0.15.10",
+        "spatie/laravel-ray": "^1.31"
     },
     "autoload": {
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
         },
         "files": [
             "./vendor/squizlabs/php_codesniffer/autoload.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     },
     "config": {
         "preferred-install": {

--- a/config/commands.php
+++ b/config/commands.php
@@ -56,7 +56,7 @@ return [
     |
     */
 
-    'hidden' => [
+    'hidden' => array_filter([
         NunoMaduro\LaravelConsoleSummary\SummaryCommand::class,
         Symfony\Component\Console\Command\DumpCompletionCommand::class,
         Symfony\Component\Console\Command\HelpCommand::class,
@@ -66,15 +66,15 @@ return [
         Illuminate\Foundation\Console\VendorPublishCommand::class,
         LaravelZero\Framework\Commands\StubPublishCommand::class,
 
-        Pest\Laravel\Commands\PestDatasetCommand::class,
-        Pest\Laravel\Commands\PestInstallCommand::class,
-        Pest\Laravel\Commands\PestTestCommand::class,
+        class_exists('Pest\Laravel\Commands\PestDatasetCommand') ? Pest\Laravel\Commands\PestDatasetCommand::class : null,
+        class_exists('Pest\Laravel\Commands\PestInstallCommand') ? Pest\Laravel\Commands\PestInstallCommand::class : null,
+        class_exists('Pest\Laravel\Commands\PestTestCommand') ? Pest\Laravel\Commands\PestTestCommand::class : null,
 
         LaravelZero\Framework\Commands\MakeCommand::class,
         LaravelZero\Framework\Commands\TestMakeCommand::class,
         LaravelZero\Framework\Commands\RenameCommand::class,
         LaravelZero\Framework\Commands\InstallCommand::class,
-    ],
+    ]),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows Duster to be built without including dev dependencies.  This reduces the filesize of the phar by about 33%.