### PR TITLE
Add notices about commits and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ Create a `pint.json` file in your project root, you can use [Duster's `pint.json
 
 There's a [GitHub Action](https://github.com/tighten/duster-action) you use to clean-up your workflows.
 
+
+
+>**Warning** Heads Up! Workflows that commit to your repo will stop any currently running workflows and not trigger another workflow run.
+
+One solution is to run your other workflows after Duster has completed by updating the trigger on those workflows:
+
+```yml
+on:
+  # Commits made in Duster Fix will not trigger any workflows
+  # This workflow is configured to run after Duster finishes
+  workflow_run:
+    workflows: ["Duster Fix"]
+    types:
+      - completed
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/app/Commands/GitHubActionsCommand.php
+++ b/app/Commands/GitHubActionsCommand.php
@@ -2,9 +2,10 @@
 
 namespace App\Commands;
 
-use LaravelZero\Framework\Commands\Command;
-
 use function Termwind\{render};
+
+use Illuminate\Support\Str;
+use LaravelZero\Framework\Commands\Command;
 
 class GitHubActionsCommand extends Command
 {
@@ -24,6 +25,14 @@ class GitHubActionsCommand extends Command
         $choice = $this->choice('Which GitHub action would you like?', array_keys($choices), 0);
 
         $workflowName = $choices[$choice];
+
+        if (Str::contains($workflowName, 'fix')) {
+            $this->warn('The resulting commit will stop any currently running workflows and will not trigger another.');
+            $this->warn('Checkout Duster\'s documentation for a workaround.');
+            if (! $this->confirm('Do you wish to continue?', true)) {
+                return Command::FAILURE;
+            }
+        }
 
         $workflow = file_get_contents(__DIR__ . "/../../stubs/github-actions/{$workflowName}.yml");
         $workflow = str_replace('YOUR_BRANCH_NAME', $branch, $workflow);

--- a/app/Commands/GitHubActionsCommand.php
+++ b/app/Commands/GitHubActionsCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use function Termwind\{render};
-
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
+
+use function Termwind\{render};
 
 class GitHubActionsCommand extends Command
 {

--- a/stubs/github-actions/duster-fix-blame.yml
+++ b/stubs/github-actions/duster-fix-blame.yml
@@ -1,5 +1,8 @@
 name: Duster Fix
 
+# Commits made in here will not trigger any workflows
+# Checkout Duster's documentation for a workaround
+
 on:
     push:
         branches: [ YOUR_BRANCH_NAME ]

--- a/stubs/github-actions/duster-fix.yml
+++ b/stubs/github-actions/duster-fix.yml
@@ -1,5 +1,8 @@
 name: Duster Fix
 
+# Commits made in here will not trigger any workflows
+# Checkout Duster's documentation for a workaround
+
 on:
     push:
         branches: [ YOUR_BRANCH_NAME ]


### PR DESCRIPTION
This PR adds some notices to let users know about some limitations with the commit workflows.

--- 

When Duster fixes the codebase, the resulting commit will not trigger another GitHub Actions Workflow run. This is due to [limitations set by GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

>When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

The commit also stops any current workflows running. This means the last three commits to the repository would not have been tested.