### PR TITLE
TLint support paths with spaces

### DIFF
--- a/app/Support/TLint.php
+++ b/app/Support/TLint.php
@@ -35,7 +35,7 @@ class TLint extends Tool
         $application->setAutoExit(false);
 
         $success = collect($this->dusterConfig->get('paths'))->map(function ($path) use ($application, $command) {
-            $path = str_replace('\\', '\\\\', $path);
+            $path = '"' . str_replace('\\', '\\\\', $path) . '"';
 
             return $application->run(new StringInput("{$command} {$path}"), app()->get(OutputInterface::class));
         })


### PR DESCRIPTION
Duster fails the TLint stage for projects which contain a space in their path.

```
./vendor/bin/duster lint

Linting using TLint

  Too many arguments to "lint" command, expected arguments "file or directory".


lint [--diff] [--json] [--only ONLY] [--] [<file or directory>]

Linting using PHP_CodeSniffer
............................................................  60 / 144 (42%)
.........................E.................................. 120 / 144 (83%)
........................                                     144 / 144 (100%)

...
```

Moving the project to a path without spaces allows the TLint stage to work as expected -

```
./vendor/bin/duster lint

Linting using TLint
Lints for /tmp/propjecttest/routes/auth.php
============
! No leading slashes on route paths.
15 : `Route::get('/auth/redirect', function () {`
! No leading slashes on route paths.
19 : `Route::get('/auth/callback', function () {`
! Prefer `Namespace\...` over `\Namespace\...`.
22 : `    $user = \App\Models\User::updateOrCreate(`
```

Wrapping the path within quotes appears to resolve the issue on my side.