### PR TITLE
Added processTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ The key is the name of the command (used with the `--using` flag), and the value
         "lint": {
             "phpstan": ["./vendor/bin/phpstan", "analyse"]
         }
-    }
+    },
+    "processTimeout": 120
 }
 ```
 
-Duster will pick these up automatically when running either `lint` or `fix`.
+Duster will pick these up automatically when running either `lint` or `fix`.  
+By default, additional scripts timeout after 60 seconds. You can overwrite this setting using the `processTimeout` key.
 
 To customize which tools Duster runs, or the order in which they are executed you can use the `--using` flag and supply a comma-separated list of commands:
 

--- a/app/Support/UserScript.php
+++ b/app/Support/UserScript.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 class UserScript extends Tool
@@ -33,11 +34,21 @@ class UserScript extends Tool
 
     private function process(): int
     {
+        $dusterConfig = DusterConfig::loadLocal();
+
         $process = new Process($this->command);
+        $process->setTimeout($dusterConfig['processTimeout'] ?? 60);
         $output = app()->get(OutputInterface::class);
 
-        $process->run(fn ($type, $buffer) => $output->write($buffer));
+        try {
+            $process->run(fn($type, $buffer) => $output->write($buffer));
 
-        return $process->getExitCode();
+            return $process->getExitCode();
+        }
+        catch(ProcessTimedOutException $e) {
+            $this->failure($e->getMessage() . '<br />You can overwrite this timeout with the processTimeout key in your duster.json file.');
+
+            return 1;
+        }
     }
 }

--- a/app/Support/UserScript.php
+++ b/app/Support/UserScript.php
@@ -41,11 +41,10 @@ class UserScript extends Tool
         $output = app()->get(OutputInterface::class);
 
         try {
-            $process->run(fn($type, $buffer) => $output->write($buffer));
+            $process->run(fn ($type, $buffer) => $output->write($buffer));
 
             return $process->getExitCode();
-        }
-        catch(ProcessTimedOutException $e) {
+        } catch(ProcessTimedOutException $e) {
             $this->failure($e->getMessage() . '<br />You can overwrite this timeout with the processTimeout key in your duster.json file.');
 
             return 1;


### PR DESCRIPTION
This PR adds a `processTimeout` option to the duster.json configuration file. This option allows the user to set the process timeout (in seconds) for any additional scripts that are ran.  

Example duster.json:
```json
{
  "scripts": {
    "lint": {
      "phpstan": ["./sleep.sh"]
    }
  },
  "processTimeout": 1
}
```

Result:
<img width="968" alt="Screenshot 2023-03-17 at 19 49 41" src="https://user-images.githubusercontent.com/21341801/225992691-91be8cd9-3c8c-447f-abdf-837c1bed0540.png">

The default timeout is set to 60 seconds, as is the Symfony default. Resolves Issue #97 