### PR TITLE
[2.x] Update GH action PHP matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
     push:
-        branches: [ main ]
+        branches: [ 2.x ]
     pull_request:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        php: ['8.0', 8.1, 8.2]
+        php: [8.1, 8.2]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run PHPStan
         run: vendor/bin/phpstan
-        if: matrix.php == '8.1'
+        if: matrix.php == '8.2'
 
       - name: Run Pest
         run: vendor/bin/pest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
 # Release Instructions
 
 1. Visit the [Duster Releases page](https://github.com/tighten/duster/releases); figure out what your next tag will be (increase the third number if it's a patch or fix; increase the second number if it's adding features)
-2. On your local machine, pull down the latest changes on the `main` branch (`git checkout main && git pull`)
+2. On your local machine, pull down the latest changes on the `2.x` branch (`git checkout 2.x && git pull`)
 3. Update the version in [`config/app.php`](./config/app.php)
 4. Update dependencies and remove dev dependencies by running `composer update`
-5. Compile the binary with (run on PHP < `8.2`)
+5. Compile the binary
 
 ```zsh
 ./duster app:build
@@ -13,5 +13,5 @@
 6. Run the build once to make sure it works (`./builds/duster`)
 7. Commit all changes
 8. Push all commits to GitHub
-9. [Draft a new release](https://github.com/tighten/duster/releases/new) with both the tag version and title of your tag (e.g. `v1.5.1`)
+9. [Draft a new release](https://github.com/tighten/duster/releases/new) with both the tag version and title of your tag (e.g. `v2.5.1`)
 10. Use the "Generate release notes" button to generate release notes from the merged PRs.


### PR DESCRIPTION
This PR updates the GH action testing matrix to drop PHP 8.0