### PR TITLE
Add and update `ref` and `repository` in GH stubs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,8 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Install dependencies
-        run: composer install
-
-      - name: Add dev dependencies
-        run: composer require --dev larastan/larastan pestphp/pest
+      - name: Install dev dependencies
+        run: COMPOSER=composer-dev.json composer install
 
       - name: Run Duster
         run: ./builds/duster lint --using="tlint,phpcodesniffer,phpcsfixer,pint"

--- a/stubs/github-actions/duster-fix-blame.yml
+++ b/stubs/github-actions/duster-fix-blame.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Duster Fix"
         uses: tighten/duster-action@v3

--- a/stubs/github-actions/duster-fix.yml
+++ b/stubs/github-actions/duster-fix.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: "Duster Fix"
         uses: tighten/duster-action@v3

--- a/stubs/github-actions/duster-lint.yml
+++ b/stubs/github-actions/duster-lint.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: "Duster Lint"
         uses: tighten/duster-action@v3
         with:


### PR DESCRIPTION
This PR adds and updates `actions/checkout` by including `ref` and `repository`.

`ref: ${{ github.event.pull_request.head.ref }}`: This specifies the branch or tag ref that should be checked out. In this case, it's dynamically set to the branch associated with the pull request that triggered the workflow.

`repository: ${{ github.event.pull_request.head.repo.full_name }}`: This specifies the repository to be checked out. It's dynamically set to the repository associated with the pull request that triggered the workflow. This is useful when the workflow is triggered by a pull request from a forked repository.

If you commit directly to the main branch instead of creating a pull request, the `github.event.pull_request.head.ref` value will not be available and the `actions/checkout` action will default to checking out the commit that triggered the workflow run.