### PR TITLE
Don't provide defaults when using custom PHP Code Sniffer config

### DIFF
--- a/app/Support/PhpCodeSniffer.php
+++ b/app/Support/PhpCodeSniffer.php
@@ -74,6 +74,10 @@ class PhpCodeSniffer extends Tool
      */
     private function getPaths(): array
     {
+        if ($this->getConfigFile() !== 'Tighten') {
+            return [];
+        }
+
         return $this->dusterConfig->get('paths') === [Project::path()]
             ? $this->getDefaultDirectories() : $this->dusterConfig->get('paths');
     }


### PR DESCRIPTION
This PR allows any custom configs to override PHP Code Sniffer default paths. 

Closes #173 