### PR TITLE
Adds a Laravel Boost guideline for Duster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: tests
 
 on:
-    push:
-        branches: [ 3.x ]
-    pull_request:
+  push:
+    branches: [3.x]
+  pull_request:
 
 jobs:
   tests:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022]
         php: [8.2, 8.3]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,4 @@
+## Duster Code Formatter
+
+- You must run `vendor/bin/duster fix --dirty` before finalizing changes to ensure your code matches the project's expected style.
+- Duster wraps Pint and other formatters, so never run Pint directly. Always prefer Duster for formatting tasks.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,4 +1,4 @@
 ## Duster Code Formatter
 
 - You must run `vendor/bin/duster fix --dirty` before finalizing changes to ensure your code matches the project's expected style.
-- Duster wraps Pint and other formatters, so never run Pint directly. Always prefer Duster for formatting tasks.
+- Duster wraps Laravel Pint and other formatters, so never run Pint directly. Always prefer Duster for formatting tasks.


### PR DESCRIPTION
### Changed

- Adds a Laravel Boost guideline. This should be identified by Boost when installing the AI guidelines (see screenshot)
- Bumps the windows runner to `windows-2022` since  `windows-2019` was discontinued ([source](https://github.com/actions/runner-images/issues/12045))

---

<details>
<summary>Screenshot</summary>

<img width="1360" height="2110" alt="image" src="https://github.com/user-attachments/assets/63defab2-f96e-43e3-9517-9091e0033728" />

</details>