### PR TITLE
Exclude the tests directory from env() ban

### DIFF
--- a/standards/Tighten/ruleset.xml
+++ b/standards/Tighten/ruleset.xml
@@ -63,6 +63,7 @@
     <!-- Use config() over env() -->
     <rule ref="Tighten.PHP.UseConfigOverEnv">
         <exclude-pattern>/config/*</exclude-pattern>
+        <exclude-pattern>/tests/*</exclude-pattern>
     </rule>
 
     <!-- Class name should match the file name -->


### PR DESCRIPTION
Tests don't cache `config()` *and* [Dusk uses `env()` by default](https://github.com/laravel/dusk/blob/8.x/stubs/DuskTestCase.stub#L44), so it's safe (and Laravel-default-friendly) to allow `env()` usage in tests.