### PR TITLE
Added trailing slash to excluded directories

### DIFF
--- a/app/Support/DusterConfig.php
+++ b/app/Support/DusterConfig.php
@@ -19,12 +19,12 @@ class DusterConfig
         '_ide_helper_models.php',
         '_ide_helper.php',
         '.phpstorm.meta.php',
-        'bootstrap/cache',
-        'build',
-        'node_modules',
-        'storage',
+        'bootstrap/cache/',
+        'build/',
+        'node_modules/',
+        'storage/',
         'tests/Pest.php',
-        'vendor',
+        'vendor/',
     ];
 
     /**

--- a/tests/Unit/DusterConfigTest.php
+++ b/tests/Unit/DusterConfigTest.php
@@ -49,11 +49,11 @@ it('merges provided exclude with default exclude config values', function () {
         '_ide_helper_models.php',
         '_ide_helper.php',
         '.phpstorm.meta.php',
-        'bootstrap/cache',
-        'build',
-        'node_modules',
-        'storage',
+        'bootstrap/cache/',
+        'build/',
+        'node_modules/',
+        'storage/',
         'tests/Pest.php',
-        'vendor',
+        'vendor/',
     ]);
 });

--- a/tests/Unit/DusterConfigTest.php
+++ b/tests/Unit/DusterConfigTest.php
@@ -25,12 +25,12 @@ it('provides default exclude config values', function () {
         '_ide_helper_models.php',
         '_ide_helper.php',
         '.phpstorm.meta.php',
-        'bootstrap/cache',
-        'build',
-        'node_modules',
-        'storage',
+        'bootstrap/cache/',
+        'build/',
+        'node_modules/',
+        'storage/',
         'tests/Pest.php',
-        'vendor',
+        'vendor/',
     ]);
 });
 


### PR DESCRIPTION
PHPCodeSniffer is treating paths in `ignore` option as patterns, when passing path `build`, paths like `/build/`, `/builds/`, `/building/` and so on, are all ignored, same for other default paths.
As pointed out in #201, GitLab CI is by default using `/builds/` directory for running jobs, so whole contents is excluded.
Adding trailing slash should fix this behavior, but PHPCodeSniffer still matches paths like `/notbuild/` and ignores them.
So there probably should be leading slash, but this could affect other tools. This seems like reasonable hotfix.
Hopefully it will not cause any side effects.
Should fix issues #200, #201 .

