### PR TITLE
Update PHPUnit from attributes to annotation

### DIFF
--- a/standards/pint.json
+++ b/standards/pint.json
@@ -37,6 +37,7 @@
                 "function"
             ]
         },
+        "php_unit_attributes": true,
         "php_unit_test_annotation": {
             "style": "annotation"
         },


### PR DESCRIPTION
Before this PR, Duster recommended/fixed to the PHPUnit now-deprecated **annotations** (`/** @test */`). This PR updates it to use the new **attributes** (`#[Test]`).

Here's the concern: it also re-writes every other PHPUnit annotation (`@dataProvider`, `@covers`, `@depends`, …) into the attribute form.


## Pros
- Resolves the PHPUnit 11.5 deprecation warning; forward-compatible with PHPUnit 12, where doc-comment metadata is removed entirely
- Modernizes all the other PHPUnit annotations PHPUnit is deprecating
- Only touches PHPUnit metadata; leaves general PHPDoc (`@param`, `@return`, `@var`, `@throws`, …) alone.

## Cons
- Huge re-write/Duster failure on first run for people with codebases written using the older syntax, which makes me wonder if we have to attach this to a larger release
- Attributes require PHP 8 / PHPUnit 10+. Projects on older versions will now need to override this rule locally


Closes #219